### PR TITLE
If the client doesn't remove the channel from the saved list on kick,…

### DIFF
--- a/htdocs/js/comm.js
+++ b/htdocs/js/comm.js
@@ -569,13 +569,11 @@ app.comm = {
 		delete channel.ui;
 		delete channel.live_users;
 		
-		// also remove channel from prefs, but only if not kicked
-		if (data.reason != 'kick') {
-			app.config.set( 'channel_order', app.config.get('channel_order').filter( function(value) { 
-				return value != chan; 
-			} ) );
-		}
-		
+		// also remove channel from prefs
+		app.config.set( 'channel_order', app.config.get('channel_order').filter( function(value) {
+			return value != chan;
+		} ) );
+
 		// show notification if reason was 'private', 'delete', etc.
 		switch (data.reason) {
 			case 'private':


### PR DESCRIPTION
… then if they are flapping (like Todd does) they will just keep rejoining, after each socket reconnect/login.   Removing the channel from the saved list, then requires someone to deliberately click the + and add the channel back in.